### PR TITLE
Compatibility with steno logger.

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -910,7 +910,7 @@ module Git
 
       if @logger
         @logger.info(git_cmd)
-        @logger.debug(output)
+        @logger.debug(output) if output
       end
             
       if exitstatus > 1 || (exitstatus == 1 && output != '')


### PR DESCRIPTION
Don't log if there is nothing to log. Steno logger raises if this is the case. 

In the case where you are attempting a push and everything is up to date, there will be no 'output', causing steno_logger to raise.