### PR TITLE
Handle the empty string case

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -910,7 +910,7 @@ module Git
 
       if @logger
         @logger.info(git_cmd)
-        @logger.debug(output) if output
+        @logger.debug(output) unless output.to_s == ''
       end
             
       if exitstatus > 1 || (exitstatus == 1 && output != '')


### PR DESCRIPTION
For steno logger compatibility, don't log if the first param ('event') is null or empty string.